### PR TITLE
feat: exclude some of niri's weak dependencies

### DIFF
--- a/recipes/common.yml
+++ b/recipes/common.yml
@@ -17,7 +17,9 @@ modules:
     src: /out/matugen
     dest: /usr/bin/
 
-  - type: dnf 
+  - type: dnf
+    # source: ghcr.io/benoitlx/modules/dnf
+    # source: local
     repos:
       copr:
         - yalter/niri # packaged by the maintainer
@@ -78,13 +80,15 @@ modules:
 
         # dev
         - gcc
+      exclude:
+        - alacritty
+        - waybar
+        - waybar-git
+        - fuzzel
     remove:
       packages:
-        - alacritty
         - htop
-        - waybar
         - firefox
-        - fuzzel
 
   - type: fonts
     fonts:

--- a/recipes/common.yml
+++ b/recipes/common.yml
@@ -18,8 +18,6 @@ modules:
     dest: /usr/bin/
 
   - type: dnf
-    # source: ghcr.io/benoitlx/modules/dnf
-    # source: local
     repos:
       copr:
         - yalter/niri # packaged by the maintainer
@@ -40,17 +38,18 @@ modules:
         - mate-polkit
         - pavucontrol
         - rofi-wayland
-        # portal
-        - xdg-desktop-portal-gtk
-        - xdg-desktop-portal-gnome
         - xwayland-satellite
-        - gnome-keyring
         - swww
         - nautilus
         - samba
         - gvfs-fuse
         - gvfs-smb
         - light
+
+        # part of niri's weak dependencies
+        # - xdg-desktop-portal-gtk
+        # - xdg-desktop-portal-gnome
+        # - gnome-keyring
 
         # Term emulator
         - kitty
@@ -85,6 +84,8 @@ modules:
         - waybar
         - waybar-git
         - fuzzel
+        - mako
+        - swaybg
     remove:
       packages:
         - htop


### PR DESCRIPTION
Make use of the new bluebuild [exclude](https://github.com/blue-build/modules/pull/462) feature